### PR TITLE
Fixing up removing

### DIFF
--- a/DailyPlanning/app/src/main/java/com/general/dailyplanning/activities/MainActivity.java
+++ b/DailyPlanning/app/src/main/java/com/general/dailyplanning/activities/MainActivity.java
@@ -58,7 +58,8 @@ public class MainActivity extends AppCompatActivity {
     private LinearLayout mainLayout;
     private TextView taskView;
 
-
+    // States
+    private static boolean isRunning = false;
 
     // Clock
     private final Handler timeClock = new Handler();
@@ -82,6 +83,7 @@ public class MainActivity extends AppCompatActivity {
         // Run only in portrait mode
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
+        isRunning = true;
         // Loading data from file
         // ONLY ONE INPUT DATA FROM FILE
         Log.d("testing", "LOAD");
@@ -101,9 +103,7 @@ public class MainActivity extends AppCompatActivity {
 
         // Background service
 
-        Log.d("testing_service", "STOP");
-        stopService(new Intent(this, TaskService.class));
-        //startService(new Intent(this, TaskService.class));
+        startService(new Intent(this, TaskService.class));
 
         // Background service
 
@@ -230,9 +230,6 @@ public class MainActivity extends AppCompatActivity {
 
                     vault.removeFromToDoList(idTask);
 
-                    // Save vault
-                    //DataManipulator.saving(context,"data", vault);
-
                     // Refresh panel with new data
                     updateToDoList();
                 }
@@ -332,13 +329,15 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public void onDestroy() {
-        //Log.d("testing", "SAVING");
+        Log.d("testing", "SAVING");
         DataManipulator.saving(this, "data", Vault.getInstance());
 
-
-        Log.d("testing_service", "START");
-        startService(new Intent(this, TaskService.class));
+        isRunning = false;
 
         super.onDestroy();
+    }
+
+    public static boolean isIsRunning() {
+        return isRunning;
     }
 }

--- a/DailyPlanning/app/src/main/java/com/general/dailyplanning/activities/UsingActivity.java
+++ b/DailyPlanning/app/src/main/java/com/general/dailyplanning/activities/UsingActivity.java
@@ -82,15 +82,6 @@ public class UsingActivity extends AppCompatActivity {
 
             Task task;
 
-            // TODO:
-            // 1st try -  Maybe remove this pushTime loop and just in Service loop call static method like:
-            // On removing tasks from Service call:
-            // UsingActivity.updateTaskList();
-
-            // 2nd try - Test what would be if I remove notification builder from here
-            // So, service will be just removed and make notifications and usingActivity will make updating of taskList
-
-
             while((task = vault.pushTimeLine(time)) != null) {
 
                  builder = new NotificationCompat.Builder(context)
@@ -101,19 +92,16 @@ public class UsingActivity extends AppCompatActivity {
                 notification = builder.build();
                 notificationManager.notify(id++, notification);
 
-
-                Log.d("testing", "removed from UsingActivity + update - " + task.getTask());
-
                 removed = true;
             }
 
             if (removed) {
                 updateTaskList();
+                updateTaskList();
             }
 
             // Update time every hh:mm:00 second
             timeClock.postDelayed(this, (60 - seconds) * 1000);
-
         }
     };
 
@@ -158,9 +146,6 @@ public class UsingActivity extends AppCompatActivity {
         // Set touch listener to show "+" button
         TouchSwipeDateListener swdl = new TouchSwipeDateListener(this, buttonAddNewTask);
         layoutDate.setOnTouchListener(swdl);
-
-        // Filling up taskList with some information
-        //updateTaskList();
     }
 
     /**
@@ -177,8 +162,6 @@ public class UsingActivity extends AppCompatActivity {
 
         Converter converter = new Converter(getWindowManager().getDefaultDisplay());
 
-
-        Log.d("testing", "scrollLayout.count: " + scrollLayout.getChildCount());
         // Clear a body
 
         if (scrollLayout.getChildCount() > 0) {
@@ -188,7 +171,7 @@ public class UsingActivity extends AppCompatActivity {
 
         LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(converter.getWidth(0.14), LinearLayout.LayoutParams.WRAP_CONTENT);
 
-        //int id = 0;
+        int id = 0;
         for (Task task: Vault.getInstance().getArray()) {
             // Task Block
             view = new TextView(this);
@@ -249,11 +232,7 @@ public class UsingActivity extends AppCompatActivity {
                     // Remove necessary element
                     vault.remove(idTask);
 
-                    // Save vault
-                    //DataManipulator.saving(context,"data", vault);
-
                     updateTaskList();
-                    // TODO: Add anim (Maybe set visibility for removed element like "GONE")
                 }
             });
             innerLayout.addView(buttonDelete);

--- a/DailyPlanning/app/src/main/java/com/general/dailyplanning/activities/UsingActivity.java
+++ b/DailyPlanning/app/src/main/java/com/general/dailyplanning/activities/UsingActivity.java
@@ -61,7 +61,6 @@ public class UsingActivity extends AppCompatActivity {
     // States
     private boolean taskOpened = false;
 
-
     // Notification's vars
     private NotificationCompat.Builder builder;
     private Notification notification;
@@ -96,8 +95,7 @@ public class UsingActivity extends AppCompatActivity {
             }
 
             if (removed) {
-                updateTaskList();
-                updateTaskList();
+               recreate();
             }
 
             // Update time every hh:mm:00 second

--- a/DailyPlanning/app/src/main/java/com/general/dailyplanning/components/TaskService.java
+++ b/DailyPlanning/app/src/main/java/com/general/dailyplanning/components/TaskService.java
@@ -13,15 +13,19 @@ import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 
 import com.general.dailyplanning.R;
+import com.general.dailyplanning.activities.MainActivity;
+import com.general.dailyplanning.activities.UsingActivity;
 import com.general.dailyplanning.data.DataManipulator;
 import com.general.dailyplanning.data.Task;
 import com.general.dailyplanning.data.Vault;
 
+import java.lang.ref.WeakReference;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 
 public class TaskService extends Service {
+    final String TAG = "testing";
     // Variables
     private int id = 1;
     private Context mContext;
@@ -37,23 +41,29 @@ public class TaskService extends Service {
     public void onCreate() {
         super.onCreate();
         notificationManager = (NotificationManager) getSystemService(Service.NOTIFICATION_SERVICE);
+        mHandler = new Handler();
     }
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        mHandler = new Handler();
+        Log.d(TAG, "onStartCommand: ");
         mContext = this;
         mVault = DataManipulator.loading(this, "data");
         int seconds = Integer.parseInt(new SimpleDateFormat("ss", Locale.US).format(new Date()));
 
-        //mHandler.postDelayed( taskRunnable, (60 - seconds) * 1000);
-        mHandler.postDelayed(taskRunnable, 0);
+        if (!MainActivity.isIsRunning()) {
+            mHandler.postDelayed(taskRunnable, 0);
+        } else {
+            mHandler.removeCallbacksAndMessages(null);
+        }
+
         return START_STICKY;
     }
 
 
     final Runnable taskRunnable = new Runnable(){
         public void run(){
+            Log.d(TAG, "run: ");
             // Get current time
             String time = new SimpleDateFormat("HH:mm", Locale.US).format(new Date());
             Task task;
@@ -67,13 +77,12 @@ public class TaskService extends Service {
                 notification = builder.build();
 
                 notificationManager.notify(id++, notification);
-
                 // Save data
                 DataManipulator.saving(mContext,"data", mVault);
             }
 
             // Repeat every 1 minute
-            mHandler.postDelayed(taskRunnable, 60000);
+            mHandler.postDelayed(taskRunnable, 3000);
         }
     };
 
@@ -82,4 +91,6 @@ public class TaskService extends Service {
     public IBinder onBind(Intent intent) {
         return null;
     }
+
+
 }

--- a/DailyPlanning/app/src/main/java/com/general/dailyplanning/components/TaskService.java
+++ b/DailyPlanning/app/src/main/java/com/general/dailyplanning/components/TaskService.java
@@ -52,7 +52,7 @@ public class TaskService extends Service {
         int seconds = Integer.parseInt(new SimpleDateFormat("ss", Locale.US).format(new Date()));
 
         if (!MainActivity.isIsRunning()) {
-            mHandler.postDelayed(taskRunnable, 0);
+            mHandler.postDelayed(taskRunnable, (60 - seconds) * 1000);
         } else {
             mHandler.removeCallbacksAndMessages(null);
         }
@@ -82,7 +82,7 @@ public class TaskService extends Service {
             }
 
             // Repeat every 1 minute
-            mHandler.postDelayed(taskRunnable, 3000);
+            mHandler.postDelayed(taskRunnable, 60000);
         }
     };
 
@@ -91,6 +91,4 @@ public class TaskService extends Service {
     public IBinder onBind(Intent intent) {
         return null;
     }
-
-
 }

--- a/DailyPlanning/app/src/main/java/com/general/dailyplanning/data/Vault.java
+++ b/DailyPlanning/app/src/main/java/com/general/dailyplanning/data/Vault.java
@@ -130,6 +130,7 @@ public class Vault implements Serializable {
         int m = Integer.parseInt(time.substring(3, 5));
         int currTime = makeNum(h, m);
 
+        // TODO: Remove loop from it. Just add 1 condition to 1st element in array (using 'get' method)
         Task toReturn;
         for (int i = 0; i < array.size(); i++) {
             toReturn = array.get(i);

--- a/DailyPlanning/app/src/main/res/layout/activity_using.xml
+++ b/DailyPlanning/app/src/main/res/layout/activity_using.xml
@@ -52,7 +52,7 @@
                 android:overScrollMode="never">
 
                 <LinearLayout
-                    android:id="@+id/scrollLayout"
+                    android:id="@+id/scrollLayout_using"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"/>


### PR DESCRIPTION
Used not quite well, but working version of fixing up an android bug.
So I replaced updating of task-list on the system method of recreating of the whole activity.

Now, when UsingActivity is running and the clock removes task then an activity will be recreated completely. It is used because LinearLayout does not refresh a body after removing views from it. 
(Also can be fixed up with removing "windowFullscreen" flag)

 